### PR TITLE
Create endpoint for users to view all items they are selling and bidding on

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -226,3 +226,32 @@ returns
   "message": "<error_message>"
 }
 ```
+
+### View all items selling and bidding
+GET /api/items/me
+
+returns
+```
+{
+  "data": {
+    "items_selling": [<ITEM_MODEL_ABOVE>],
+    "items_bidding": [
+      {
+        "item_name": "<item_name>",
+        "seller_id": <RAFFLEBAY_USER_ID>,
+        "pic_url": "<item_pic_url>",
+        "item_description": "<item_description>",
+        "tags": "<item_tags>",
+        "sale_price": <item_sale_price>,
+        "ticket_price": <item_ticket_price>,
+        "total_tickets": <item_total_number_tickets>,
+        "status": "<item_current_status>",
+        "deadline": "<item_deadline_timestamp>"
+        "total_cost": <total_ticket_cost>,
+        "tickets_bought": <total_tickets_bought>
+      }
+    ]
+  },
+  "message": "<error_message>"
+}
+```

--- a/backend/src/controllers/item.js
+++ b/backend/src/controllers/item.js
@@ -174,11 +174,8 @@ const ItemController = (itemModel, userModel, authService) => {
       
     }
 
-
-
-
     // Return one data object with all the items the user is selling an the items the user is bidding on
-    const data = {"Items Selling": items_selling, "Items Bidding On": items_bidding}
+    const data = {"items_selling": items_selling, "items_bidding": items_bidding}
 
     return res.status(200).json({
       data: data,

--- a/backend/src/controllers/item.js
+++ b/backend/src/controllers/item.js
@@ -132,7 +132,8 @@ const ItemController = (itemModel, userModel, authService) => {
     });
   });
 
-  // Gets the logged in user using the authentication token passed in the request header
+  // Gets the list of all items that the user is selling and all items that the user has bid on 
+  // Uses the authentication token to get the user information
   router.get('/me', async (req, res) => {
   
     // Get the user_id of the user sending the request
@@ -145,7 +146,7 @@ const ItemController = (itemModel, userModel, authService) => {
       });
     }
 
-    // Get all items that are sold by the user
+    // Get all items where the logged in user is the seller
     const [items_selling, err1] = await itemModel.getItemsForSeller(user_info['id'])
 
     if (err1) {
@@ -155,7 +156,7 @@ const ItemController = (itemModel, userModel, authService) => {
       });
     }
 
-    // Get all the bids from theuser
+    // Get all of the items that the user has bid on
     const [bid_info, err2] = await itemModel.getBidsForUser(user_info['id'])
     
     if (err2) {
@@ -165,7 +166,8 @@ const ItemController = (itemModel, userModel, authService) => {
       });
     }
 
-    // Only return the information 
+    // Users who bid on items should see limited information about the items
+    // Make sure each item that is returned only has the specfic information included
     var items_bidding = []
     var arrayLength = bid_info.length;
     for (var i = 0; i < arrayLength; i++) {
@@ -174,7 +176,7 @@ const ItemController = (itemModel, userModel, authService) => {
       
     }
 
-    // Return one data object with all the items the user is selling an the items the user is bidding on
+    // Return one data object with all of the items the user is selling an the items the user is bidding on
     const data = {"items_selling": items_selling, "items_bidding": items_bidding}
 
     return res.status(200).json({

--- a/backend/src/models/item/index.js
+++ b/backend/src/models/item/index.js
@@ -82,6 +82,26 @@ const ItemModel = (repo) => {
     return await repo.createBid(user_id, item_id, ticket_count, total_cost);
   }
 
+  /**
+   * Get all items where user was the seller
+   * 
+   * @param  {number} seller_id - ID of user selling the item
+   * @return {Array<{0: Item, 1: String}>} - Array with Raffelbay Item Objects for seller and error (only one or the other)
+   */
+  const getItemsForSeller = async(seller_id) => {
+    return await repo.getItemsForSeller(seller_id)
+  }
+
+  /**
+   * Gets all bids for user
+   * 
+   * @param  {number} user_id - ID of user bidding on item
+   * @return {Array<{0: Bid, 1: String}>} - Array with Rafflebay Bid Objects for userand error (only one or the other)
+   */
+  const getBidsForUser = async(user_id) => {
+    return await repo.getBidsForUser(user_id)
+  }
+
   return {
     createItem,
     getItemInfo,
@@ -90,6 +110,8 @@ const ItemModel = (repo) => {
     setBidAsWinner,
     getItemsWithStatus,
     updateItemStatus,
+    getItemsForSeller,
+    getBidsForUser,
   };
 };
 


### PR DESCRIPTION
Created an endpoint for users to view all items they are selling and items they are bidding on

**GET /api/items/me**
Must include auth_token of **USER** in the header
Will return data with two sections, "items_selling" and "items_bidding". "items_selling" is an array of all the items the user has created for sale. "items_bidding" is an array of all the items the user has bought bids for, and includes how many tickets and home much total they spent on the item.
Successful get items/me images: 
![image](https://user-images.githubusercontent.com/39390609/74889695-ac2a1580-5336-11ea-831c-72fee06a57aa.png)
![image](https://user-images.githubusercontent.com/39390609/74889701-ae8c6f80-5336-11ea-88ff-6733becd4ac3.png)

