### PR TITLE
Navigation between screens and Add new item

### DIFF
--- a/frontend/RaffleBay/RaffleBay.xcodeproj/project.pbxproj
+++ b/frontend/RaffleBay/RaffleBay.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		8BE89B9523EF835400EC2076 /* SplashscreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE89B9423EF835400EC2076 /* SplashscreenView.swift */; };
 		8BE89B9723F0900500EC2076 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE89B9623F0900500EC2076 /* LoginView.swift */; };
 		A3CA20C487169747B8DBE422 /* Pods_RaffleBayTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A23D9203AF6575B8387CC6A7 /* Pods_RaffleBayTests.framework */; };
+		B247F55523FE270500FA7830 /* UploadSaleItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55423FE270500FA7830 /* UploadSaleItemView.swift */; };
+		B247F55723FE349E00FA7830 /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55623FE349E00FA7830 /* CameraController.swift */; };
 		B27513AB23ECAC47007305A0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27513AA23ECAC47007305A0 /* AppDelegate.swift */; };
 		B27513AD23ECAC47007305A0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27513AC23ECAC47007305A0 /* SceneDelegate.swift */; };
 		B27513B023ECAC47007305A0 /* RaffleBay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B27513AE23ECAC47007305A0 /* RaffleBay.xcdatamodeld */; };
@@ -109,6 +111,8 @@
 		8BE89B9623F0900500EC2076 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		A23D9203AF6575B8387CC6A7 /* Pods_RaffleBayTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RaffleBayTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABA14B827A9D72B336BFD9D8 /* Pods-RaffleBay-RaffleBayUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RaffleBay-RaffleBayUITests.debug.xcconfig"; path = "Target Support Files/Pods-RaffleBay-RaffleBayUITests/Pods-RaffleBay-RaffleBayUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		B247F55423FE270500FA7830 /* UploadSaleItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadSaleItemView.swift; sourceTree = "<group>"; };
+		B247F55623FE349E00FA7830 /* CameraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
 		B27513A723ECAC47007305A0 /* RaffleBay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RaffleBay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B27513AA23ECAC47007305A0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B27513AC23ECAC47007305A0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -312,6 +316,7 @@
 				8B3ACCF923FA48A70045F6BF /* constants.swift */,
 				8BC5210023FBABE600BCC476 /* ProfileView.swift */,
 				8BC5210223FBB25000BCC476 /* ProfileSaleItemView.swift */,
+				B247F55423FE270500FA7830 /* UploadSaleItemView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -320,6 +325,7 @@
 			isa = PBXGroup;
 			children = (
 				B2FF79FB23F5FA0900AE9572 /* LoginViewController.swift */,
+				B247F55623FE349E00FA7830 /* CameraController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -582,6 +588,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2FF79FC23F5FA0900AE9572 /* LoginViewController.swift in Sources */,
+				B247F55723FE349E00FA7830 /* CameraController.swift in Sources */,
 				8B6C220623FCA4A10014796E /* SidebarNavView.swift in Sources */,
 				B27513EA23ECAD38007305A0 /* SaleItemTableView.swift in Sources */,
 				8B6C220823FCAFF00014796E /* CreateSaleItem.swift in Sources */,
@@ -602,6 +609,7 @@
 				B27513F123ECB061007305A0 /* SignupView.swift in Sources */,
 				8B3ACCF823FA14CB0045F6BF /* styles.swift in Sources */,
 				B27513E423ECACEA007305A0 /* User.swift in Sources */,
+				B247F55523FE270500FA7830 /* UploadSaleItemView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/frontend/RaffleBay/RaffleBay.xcodeproj/project.pbxproj
+++ b/frontend/RaffleBay/RaffleBay.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		A3CA20C487169747B8DBE422 /* Pods_RaffleBayTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A23D9203AF6575B8387CC6A7 /* Pods_RaffleBayTests.framework */; };
 		B247F55523FE270500FA7830 /* UploadSaleItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55423FE270500FA7830 /* UploadSaleItemView.swift */; };
 		B247F55723FE349E00FA7830 /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55623FE349E00FA7830 /* CameraController.swift */; };
+		B247F55923FF38E600FA7830 /* AuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55823FF38E600FA7830 /* AuthenticationViewModel.swift */; };
+		B247F55B23FFA00100FA7830 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55A23FFA00100FA7830 /* ProfileViewController.swift */; };
+		B247F55D23FFAD6C00FA7830 /* CreateSaleItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F55C23FFAD6C00FA7830 /* CreateSaleItemViewController.swift */; };
 		B27513AB23ECAC47007305A0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27513AA23ECAC47007305A0 /* AppDelegate.swift */; };
 		B27513AD23ECAC47007305A0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27513AC23ECAC47007305A0 /* SceneDelegate.swift */; };
 		B27513B023ECAC47007305A0 /* RaffleBay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B27513AE23ECAC47007305A0 /* RaffleBay.xcdatamodeld */; };
@@ -113,6 +116,9 @@
 		ABA14B827A9D72B336BFD9D8 /* Pods-RaffleBay-RaffleBayUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RaffleBay-RaffleBayUITests.debug.xcconfig"; path = "Target Support Files/Pods-RaffleBay-RaffleBayUITests/Pods-RaffleBay-RaffleBayUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		B247F55423FE270500FA7830 /* UploadSaleItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadSaleItemView.swift; sourceTree = "<group>"; };
 		B247F55623FE349E00FA7830 /* CameraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
+		B247F55823FF38E600FA7830 /* AuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewModel.swift; sourceTree = "<group>"; };
+		B247F55A23FFA00100FA7830 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		B247F55C23FFAD6C00FA7830 /* CreateSaleItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSaleItemViewController.swift; sourceTree = "<group>"; };
 		B27513A723ECAC47007305A0 /* RaffleBay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RaffleBay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B27513AA23ECAC47007305A0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B27513AC23ECAC47007305A0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -295,6 +301,7 @@
 			children = (
 				B27513E123ECACD6007305A0 /* SaleItem.swift */,
 				B27513E323ECACEA007305A0 /* User.swift */,
+				B247F55823FF38E600FA7830 /* AuthenticationViewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -326,6 +333,8 @@
 			children = (
 				B2FF79FB23F5FA0900AE9572 /* LoginViewController.swift */,
 				B247F55623FE349E00FA7830 /* CameraController.swift */,
+				B247F55A23FFA00100FA7830 /* ProfileViewController.swift */,
+				B247F55C23FFAD6C00FA7830 /* CreateSaleItemViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -591,6 +600,7 @@
 				B247F55723FE349E00FA7830 /* CameraController.swift in Sources */,
 				8B6C220623FCA4A10014796E /* SidebarNavView.swift in Sources */,
 				B27513EA23ECAD38007305A0 /* SaleItemTableView.swift in Sources */,
+				B247F55D23FFAD6C00FA7830 /* CreateSaleItemViewController.swift in Sources */,
 				8B6C220823FCAFF00014796E /* CreateSaleItem.swift in Sources */,
 				8BC5210323FBB25000BCC476 /* ProfileSaleItemView.swift in Sources */,
 				8BB7CD8323FD038C00E83590 /* SuccessfulView.swift in Sources */,
@@ -599,6 +609,7 @@
 				8BE89B9523EF835400EC2076 /* SplashscreenView.swift in Sources */,
 				B27513EC23ECAD52007305A0 /* SaleItemDetailView.swift in Sources */,
 				B27513E223ECACD6007305A0 /* SaleItem.swift in Sources */,
+				B247F55923FF38E600FA7830 /* AuthenticationViewModel.swift in Sources */,
 				8B3ACCFA23FA48A70045F6BF /* constants.swift in Sources */,
 				B27513AD23ECAC47007305A0 /* SceneDelegate.swift in Sources */,
 				8BC5210123FBABE600BCC476 /* ProfileView.swift in Sources */,
@@ -608,6 +619,7 @@
 				8BE89B9723F0900500EC2076 /* LoginView.swift in Sources */,
 				B27513F123ECB061007305A0 /* SignupView.swift in Sources */,
 				8B3ACCF823FA14CB0045F6BF /* styles.swift in Sources */,
+				B247F55B23FFA00100FA7830 /* ProfileViewController.swift in Sources */,
 				B27513E423ECACEA007305A0 /* User.swift in Sources */,
 				B247F55523FE270500FA7830 /* UploadSaleItemView.swift in Sources */,
 			);

--- a/frontend/RaffleBay/RaffleBay/Controller/CameraController.swift
+++ b/frontend/RaffleBay/RaffleBay/Controller/CameraController.swift
@@ -1,0 +1,32 @@
+//
+//  CameraController.swift
+//  RaffleBay
+//
+//  Created by Meera Rachamallu on 2/19/20.
+//  Copyright © 2020 Meera Rachamallu. All rights reserved.
+//
+
+import SwiftUI
+
+class CameraController: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    
+    @Binding var isCoordinatorShown: Bool
+    @Binding var imageInCoordinator: Image?
+    
+    init(isShown: Binding<Bool>, image: Binding<Image?>) {
+        _isCoordinatorShown = isShown
+        _imageInCoordinator = image
+    }
+    
+    func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        guard let unwrapImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
+        imageInCoordinator = Image(uiImage: unwrapImage)
+        isCoordinatorShown = false
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        isCoordinatorShown = false
+    }
+}
+

--- a/frontend/RaffleBay/RaffleBay/Controller/CreateSaleItemViewController.swift
+++ b/frontend/RaffleBay/RaffleBay/Controller/CreateSaleItemViewController.swift
@@ -1,0 +1,44 @@
+//
+//  CreateSaleItemViewController.swift
+//  RaffleBay
+//
+//  Created by Meera Rachamallu on 2/20/20.
+//  Copyright © 2020 Meera Rachamallu. All rights reserved.
+//
+
+import Foundation
+import Alamofire_SwiftyJSON
+import Alamofire
+import SwiftyJSON
+func post_sale_item(saleItem: SaleItem) -> Void {
+    let parameters: [String: Any] = [
+        "item_name": saleItem.item_name,
+        "seller_id": "1",
+        "pic_url": "<url>",
+        "item_description": saleItem.item_description,
+        "tags": "fun",
+        "sale_price": saleItem.sale_price,
+        "ticket_price": saleItem.ticket_price,
+        "total_tickets": saleItem.total_tickets,
+        "bids": "4",
+        "is_ended": "False",
+        "deadline": "now",
+        "status": "cur_status",
+        "current_ledger": "0"
+    ]
+    Alamofire.request(url + "/api/items/postitem", method: .post, parameters: parameters, encoding: JSONEncoding.default)
+    .responseSwiftyJSON { dataResponse in
+        print(dataResponse.request)
+        if dataResponse.result.isSuccess {
+            let message = dataResponse.value!["message"]
+            print("message: \(message)")
+            if message == "" {
+                let data = dataResponse.value!["data"]
+                print("data: \(data)")
+            }
+        } else {
+            print(dataResponse.error)
+        }
+    };
+    
+}

--- a/frontend/RaffleBay/RaffleBay/Controller/LoginViewController.swift
+++ b/frontend/RaffleBay/RaffleBay/Controller/LoginViewController.swift
@@ -12,10 +12,12 @@ import Alamofire
 import SwiftyJSON
 func login_request(email: String, password: String) -> Int {
     var result = 0
+    print("email: \(email)")
+    print("password: \(password)")
     Alamofire.request(url + "/api/users/login", method: .post, parameters: ["email":email, "password":password])
     .responseSwiftyJSON { dataResponse in
         if dataResponse.result.isSuccess {
-            let data = dataResponse.value!["data"]
+            let data = dataResponse.value!["data"]["firstname"]
             print(data)
             let message = dataResponse.value!["message"]
             print(message)
@@ -24,5 +26,5 @@ func login_request(email: String, password: String) -> Int {
             print(dataResponse.error)
         }
     };
-    return result;
+    return 1;
 }

--- a/frontend/RaffleBay/RaffleBay/Controller/ProfileViewController.swift
+++ b/frontend/RaffleBay/RaffleBay/Controller/ProfileViewController.swift
@@ -1,8 +1,8 @@
 //
-//  LoginViewController.swift
+//  ProfileViewController.swift
 //  RaffleBay
 //
-//  Created by Meera Rachamallu on 2/13/20.
+//  Created by Meera Rachamallu on 2/20/20.
 //  Copyright © 2020 Meera Rachamallu. All rights reserved.
 //
 
@@ -10,16 +10,11 @@ import Foundation
 import Alamofire_SwiftyJSON
 import Alamofire
 import SwiftyJSON
-func login_request(email: String, password: String, authenticationVM: AuthenticationViewModel, user: User) -> Int {
-    let parameters: [String: Any] = [
-        "email": email,
-        "password": password
+func get_user_request(auth_token: String, user: User) -> Void {
+    let headers: HTTPHeaders = [
+        "Authorization": "Bearer \(auth_token)"
     ]
-    var result = 0
-    
-    print("email: \(email)")
-    print("password: \(password)")
-    Alamofire.request(url + "/api/users/login", method: .post, parameters: parameters, encoding: JSONEncoding.default)
+    Alamofire.request(url + "/api/users/1", method: .get, encoding: JSONEncoding.default, headers: headers)
     .responseSwiftyJSON { dataResponse in
         print(dataResponse.request)
         if dataResponse.result.isSuccess {
@@ -30,16 +25,13 @@ func login_request(email: String, password: String, authenticationVM: Authentica
                 let auth = data["auth_token"]
                 print("data: \(data)")
                 print("auth: \(auth)")
-                authenticationVM.auth_token = auth.string!
                 user.firstName = data["first_name"].string!
                 user.lastName = data["last_name"].string!
                 user.pic_url = data["pic_url"].string!
-                result = 1
             }
         } else {
             print(dataResponse.error)
         }
     };
     
-    return 1;
 }

--- a/frontend/RaffleBay/RaffleBay/Model/AuthenticationViewModel.swift
+++ b/frontend/RaffleBay/RaffleBay/Model/AuthenticationViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  AuthenticationViewModel.swift
+//  RaffleBay
+//
+//  Created by Meera Rachamallu on 2/20/20.
+//  Copyright © 2020 Meera Rachamallu. All rights reserved.
+//
+
+import Foundation
+
+class AuthenticationViewModel: ObservableObject {
+    @Published var auth_token: String = UserDefaults.standard.string(forKey: "auth_token")! {
+        didSet{
+            UserDefaults.standard.set(self.auth_token, forKey: "auth_token")
+        }
+    }
+}

--- a/frontend/RaffleBay/RaffleBay/Model/SaleItem.swift
+++ b/frontend/RaffleBay/RaffleBay/Model/SaleItem.swift
@@ -17,9 +17,9 @@ class SaleItem: ObservableObject {
     @Published var pic_url: String  = ""
     @Published var item_description: String = ""
     @Published var tags: String = ""
-    @Published var sale_price: Int = 0
-    @Published var ticket_price: Int = 0
-    @Published var total_tickets: Int = 0
+    @Published var sale_price: String = ""
+    @Published var ticket_price: String = ""
+    @Published var total_tickets: String = ""
     @Published var is_ended: Bool = true
     
     init(item_name: String, pic_url: String) {

--- a/frontend/RaffleBay/RaffleBay/Model/SaleItem.swift
+++ b/frontend/RaffleBay/RaffleBay/Model/SaleItem.swift
@@ -9,19 +9,21 @@
 import Foundation
 import SwiftUI
 
-struct SaleItem: Identifiable {
-    //TODO: Fill out based on class diagram
-    // unique product id
-    var id: String = UUID().uuidString
+class SaleItem: ObservableObject {
     
-    // name of product
-    let name: String
+    @Published var item_id: Int = 0
+    @Published var item_name: String = ""
+    @Published var seller_id: Int = 0
+    @Published var pic_url: String  = ""
+    @Published var item_description: String = ""
+    @Published var tags: String = ""
+    @Published var sale_price: Int = 0
+    @Published var ticket_price: Int = 0
+    @Published var total_tickets: Int = 0
+    @Published var is_ended: Bool = true
     
-    // image of product
-    let image: String
-    
-    init(name: String, image: String) {
-           self.name = name
-           self.image = image
-       }
+    init(item_name: String, pic_url: String) {
+        self.item_name = item_name
+        self.pic_url = pic_url
+    }
 }

--- a/frontend/RaffleBay/RaffleBay/Model/User.swift
+++ b/frontend/RaffleBay/RaffleBay/Model/User.swift
@@ -25,6 +25,8 @@ class User: ObservableObject {
     @Published var zipcode: String = ""
     @Published var phoneNumber: String = ""
     @Published var birthdate: String = ""
+    @Published var pic_url: String = ""
+    @Published var auth_token: String = ""
     
 //    //Should these be all private and have public getters/setters?
 //    init(firstName: String, lastName: String, email: String, password: String, streetAddress: String, city: String, state: String, zipcode: String, phoneNumber: String, birthdate: Date) {

--- a/frontend/RaffleBay/RaffleBay/Test/SaleItemTestData.swift
+++ b/frontend/RaffleBay/RaffleBay/Test/SaleItemTestData.swift
@@ -10,12 +10,12 @@ struct SaleItemTestData {
 
     /// posts
     static func saleItems() -> [SaleItem] {
-        let saleItem1 = SaleItem(name: "Bose QuietComfort 100", image: "bose")
-        let saleItem2 = SaleItem(name: "Bose QuietComfort 200", image: "bose")
-        let saleItem3 = SaleItem(name: "Bose QuietComfort 300", image: "bose")
-        let saleItem4 = SaleItem(name: "Bose QuietComfort 400", image: "bose")
-        let saleItem5 = SaleItem(name: "Bose QuietComfort 500", image: "bose")
-        let saleItem6 = SaleItem(name: "Bose QuietComfort 600", image: "bose")
+        let saleItem1 = SaleItem(item_name: "Bose QuietComfort 100", pic_url: "bose")
+        let saleItem2 = SaleItem(item_name: "Bose QuietComfort 200", pic_url: "bose")
+        let saleItem3 = SaleItem(item_name: "Bose QuietComfort 300", pic_url: "bose")
+        let saleItem4 = SaleItem(item_name: "Bose QuietComfort 400", pic_url: "bose")
+        let saleItem5 = SaleItem(item_name: "Bose QuietComfort 500", pic_url: "bose")
+        let saleItem6 = SaleItem(item_name: "Bose QuietComfort 600", pic_url: "bose")
 
 
 

--- a/frontend/RaffleBay/RaffleBay/View/ContentView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ContentView.swift
@@ -15,9 +15,26 @@ struct ContentView: View {
 
     var body: some View {
         if false{
-            return AnyView(LoginView())
+            return AnyView(SplashscreenView())
         } else {
-            return AnyView(UploadSaleItemView())
+            return AnyView(TabView(selection: $selection){
+                SaleItemTableView()
+                    .tabItem {
+                        VStack {
+                            Image("first")
+                            Text("First")
+                        }
+                    }
+                    .tag(0)
+                ProfileView()
+                    .tabItem {
+                        VStack {
+                            Image("second")
+                            Text("Second")
+                        }
+                    }
+                    .tag(1)
+            })
         }
 
     }

--- a/frontend/RaffleBay/RaffleBay/View/ContentView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
         if false{
             return AnyView(LoginView())
         } else {
-            return AnyView(SaleItemTableView())
+            return AnyView(UploadSaleItemView())
         }
 
     }

--- a/frontend/RaffleBay/RaffleBay/View/ContentView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ContentView.swift
@@ -11,8 +11,15 @@ import SwiftUI
 struct ContentView: View {
     @State private var selection = 0
  
+//    @EnvironmentObject var userAuth: UserAuth
+
     var body: some View {
-        SuccessfulView()
+        if false{
+            return AnyView(LoginView())
+        } else {
+            return AnyView(SaleItemTableView())
+        }
+
     }
 }
 

--- a/frontend/RaffleBay/RaffleBay/View/ContentView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ContentView.swift
@@ -10,11 +10,10 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selection = 0
- 
-//    @EnvironmentObject var userAuth: UserAuth
+    @ObservedObject var authenticationVM = AuthenticationViewModel()
 
     var body: some View {
-        if false{
+        if self.authenticationVM.auth_token == "" {
             return AnyView(SplashscreenView())
         } else {
             return AnyView(TabView(selection: $selection){

--- a/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
+++ b/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
@@ -46,9 +46,11 @@ struct CreateSaleItem: View {
                 }
             }.padding(20)
             NavigationLink(destination: ProfileView()){
-                Text("Add Listing")
-                  .blueButtonText()
-                  .frame(minWidth:0, maxWidth: frameMaxWidth)
+                Button(action: {post_sale_item(saleItem: self.newSaleItem)}) {
+                    Text("Add Listing")
+                      .blueButtonText()
+                      .frame(minWidth:0, maxWidth: frameMaxWidth)
+                }
             }
             .buttonStyle(BigBlueButtonStyle())
         }.padding(40)

--- a/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
+++ b/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
@@ -45,7 +45,7 @@ struct CreateSaleItem: View {
                 }
             }.padding(20)
             Button(action:{
-               
+               return AnyView(SaleItemTableView())
             }){
                 Text("Add Listing")
                     .blueButtonText()

--- a/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
+++ b/frontend/RaffleBay/RaffleBay/View/CreateSaleItem.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct CreateSaleItem: View {
+    @ObservedObject var newSaleItem: SaleItem
     var body: some View {
         VStack(){
             Spacer().frame(height: 100)
@@ -17,9 +18,9 @@ struct CreateSaleItem: View {
                     .resizable()
                     .frame(maxWidth: 350, maxHeight: 200)
                 
-                Text("saleItem.name")
+                Text(newSaleItem.item_name)
                     .h1()
-                Text("Description")
+                Text(newSaleItem.item_description)
                     .h2()
                 
             }
@@ -33,29 +34,29 @@ struct CreateSaleItem: View {
                     Text("Total List Price: ")
                         .clearButtonText()
                     Spacer()
-                    Text("$50.00")
+                    Text(newSaleItem.sale_price)
                         .clearButtonText()
                 }
                 HStack(){
                     Text("Tickets to Sell: ")
                         .clearButtonText()
                     Spacer()
-                    Text("10")
+                    Text(newSaleItem.total_tickets)
                         .clearButtonText()
                 }
             }.padding(20)
-            Button(action:{
-               return AnyView(SaleItemTableView())
-            }){
+            NavigationLink(destination: ProfileView()){
                 Text("Add Listing")
-                    .blueButtonText()
-            }.buttonStyle(BigBlueButtonStyle())
+                  .blueButtonText()
+                  .frame(minWidth:0, maxWidth: frameMaxWidth)
+            }
+            .buttonStyle(BigBlueButtonStyle())
         }.padding(40)
     }
 }
 
-struct CreateSaleItem_Previews: PreviewProvider {
-    static var previews: some View {
-        CreateSaleItem()
-    }
-}
+//struct CreateSaleItem_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CreateSaleItem(newSaleItem: SaleItem)
+//    }
+//}

--- a/frontend/RaffleBay/RaffleBay/View/LoginView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/LoginView.swift
@@ -43,7 +43,7 @@ struct LoginView: View {
 
                         //Login Button
                         //Personal Comment: Should we not have a natigation link here? I haven't looked into this yet but I'm assuming when we have a real DB hooked up, the view will change prior to recieving confirmation from the DB if the user input is correct
-                        NavigationLink(destination: SaleItemTableView(), tag: 1, selection: self.$selection){
+                        NavigationLink(destination: ContentView(), tag: 1, selection: self.$selection){
                             Button(action: {
                                 self.selection =  login_request(email: "longerbeamalex@gmail.com", password: "PASSWORD1")
                             }){

--- a/frontend/RaffleBay/RaffleBay/View/LoginView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/LoginView.swift
@@ -14,7 +14,8 @@ struct LoginView: View {
     @State private var selection: Int? = nil
     @State private var email: String = ""
     @State private var password: String = ""
-    
+    @ObservedObject var authenticationVM = AuthenticationViewModel()
+    @ObservedObject var newUser = User()
      var body: some View {
             HStack(){
                 
@@ -45,7 +46,8 @@ struct LoginView: View {
                         //Personal Comment: Should we not have a natigation link here? I haven't looked into this yet but I'm assuming when we have a real DB hooked up, the view will change prior to recieving confirmation from the DB if the user input is correct
                         NavigationLink(destination: ContentView(), tag: 1, selection: self.$selection){
                             Button(action: {
-                                self.selection =  login_request(email: "longerbeamalex@gmail.com", password: "PASSWORD1")
+                                let response = login_request(email: self.email, password: self.password, authenticationVM: self.authenticationVM, user: self.newUser)
+                                self.selection = response
                             }){
                                 Text("Login")
                                     .blueButtonText()

--- a/frontend/RaffleBay/RaffleBay/View/ProfileView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ProfileView.swift
@@ -13,6 +13,7 @@ let circleDiameter: CGFloat = 30
 
 struct ProfileView: View {
     var body: some View {
+        NavigationView {
         VStack(){
             HStack(){
                 Text("Profile")
@@ -61,9 +62,8 @@ struct ProfileView: View {
                             
                         
                         Spacer()
-                        Button(action: {
-                           
-                        }){
+                        NavigationLink(destination: UploadSaleItemView()) {
+                            
                             PlusButtonView()
                         }
                     }
@@ -81,7 +81,8 @@ struct ProfileView: View {
                 }
             }
         }
-        
+        }
+    .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/frontend/RaffleBay/RaffleBay/View/ProfileView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/ProfileView.swift
@@ -12,12 +12,18 @@ let circleDiameter: CGFloat = 30
 
 
 struct ProfileView: View {
+    @ObservedObject var currUser = User()
+    @ObservedObject var authenticationVM = AuthenticationViewModel()
     var body: some View {
         NavigationView {
         VStack(){
             HStack(){
-                Text("Profile")
-                    .h1()
+                Button(action: {
+                    self.authenticationVM.auth_token = ""
+                }){
+                   Text("logout")
+                       .h1()
+                }
                 Spacer()
                 HamburgerIconView()
             }.padding()
@@ -29,7 +35,7 @@ struct ProfileView: View {
                         .clipShape(Circle())
                         .overlay(Circle().stroke(Color.white, lineWidth: 4))
                         .shadow(radius: 7)
-                    Text("Pierson Marks")
+                    Text("\(currUser.firstName) \(currUser.lastName)")
                         .clearButtonText()
                     Text("Account Balance: $" + "47.00")
                         .standardBoldText()
@@ -83,6 +89,7 @@ struct ProfileView: View {
         }
         }
     .navigationBarBackButtonHidden(true)
+        .onAppear {if self.currUser.lastName == "" {get_user_request(auth_token: self.authenticationVM.auth_token, user: self.currUser)}}
     }
 }
 

--- a/frontend/RaffleBay/RaffleBay/View/SaleItemCellView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SaleItemCellView.swift
@@ -19,7 +19,7 @@ struct SaleItemCellView: View {
         
         VStack(spacing: 0){
             ZStack(){
-                Image(saleItem.image)
+                Image(saleItem.pic_url)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: cellWidth, maxHeight: cellHeight)
@@ -28,7 +28,7 @@ struct SaleItemCellView: View {
                 HStack(){
                     VStack(){
                         Spacer()
-                        Text(saleItem.name)
+                        Text(saleItem.item_name)
                             .saleItemText()
                             .shadow(radius: 1)
                     }.offset(x:cellWidth/40)

--- a/frontend/RaffleBay/RaffleBay/View/SaleItemDetailView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SaleItemDetailView.swift
@@ -82,3 +82,9 @@ struct SaleItemDetailView : View {
         }.padding(40)
     }
 }
+
+struct SaleItemDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        SaleItemDetailView()
+    }
+}

--- a/frontend/RaffleBay/RaffleBay/View/SaleItemDetailView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SaleItemDetailView.swift
@@ -19,7 +19,7 @@ struct SaleItemDetailView : View {
                 Image("bose")
                     .resizable()
                     .frame(maxWidth: 350, maxHeight: 200)
-                Text("saleItem.name")
+                Text("Bose QuietComfort 100")
                     .h1()
                 HStack(alignment: .top){
                     VStack(alignment: .leading){

--- a/frontend/RaffleBay/RaffleBay/View/SaleItemTableView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SaleItemTableView.swift
@@ -64,7 +64,7 @@ struct SaleItemTableView : View {
 //
 //                }
 //            }
-            Spacer().frame(height: 30)
+//            Spacer().frame(height: 30)
             TextField("Search", text: $search)
                 .padding(20)
                   .background(RoundedRectangle(cornerRadius: 8)
@@ -121,8 +121,10 @@ struct SaleItemTableView : View {
 //                }
 //            )
 //        }
+            
     }
-
+        
+    .navigationBarBackButtonHidden(true)
     }
 
 }

--- a/frontend/RaffleBay/RaffleBay/View/SaleItemTableView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SaleItemTableView.swift
@@ -38,61 +38,66 @@ struct SaleItemTableView : View {
     @State private var search: String = ""
 
     @State private var saleItems = SaleItemTestData.saleItems()
+    
     /// view body
     var body: some View {
+        NavigationView {
 
         VStack(){
-            HStack(){
-                VStack(){
-                    Button(action: {
-                        
-                    }){
-                         HamburgerIconView()
-                    }
-                    
-                    .foregroundColor(Color("LightGray"))
-                }
-                Spacer()
-                VStack(){
-                    Button(action: {
-                        
-                    }){
-                         Text("Profile")
-                    }
-                    .foregroundColor(Color("LightGray"))
-                }
-            }
+//            HStack(){
+//                VStack(){
+//                    Button(action: {
+//
+//                    }){
+//                         HamburgerIconView()
+//                    }
+//
+//                    .foregroundColor(Color("LightGray"))
+//                }
+//                Spacer()
+//                VStack(){
+//                    Button(action: {
+//
+//                    }){
+//                         Text("Profile")
+//                    }
+//
+//                }
+//            }
             Spacer().frame(height: 30)
             TextField("Search", text: $search)
                 .padding(20)
                   .background(RoundedRectangle(cornerRadius: 8)
                     .foregroundColor(Color.white).frame(height: frameMaxWidth * 1.1 / 7))
                     .shadow(radius: 7, y: 5)
-                    
+
             .frame(height: frameMaxWidth * 1.1 / 7)
             Spacer().frame(height: 30)
-            
+//
             HStack(){
                 Text("Items for Sale")
                     .fontWeight(.bold)
-                    
+
                 Spacer()
 //                Text("Sort By: Most Recent")
 //                    .fontWeight(.light)
-                    
-                    
+
+
             }
             ScrollView(){
                 //Currently this will only show the first even number of items. If there is a an odd number of sale items, the last item will not show. Will be slightly challenging to display that last item.
                 GridStack(rows: saleItems.count / 2, columns: 2) { row, col in
-                    SaleItemCellView(saleItem: self.saleItems[row * 2 + col])
+                    NavigationLink(destination: SaleItemDetailView()) {
+                        SaleItemCellView(saleItem: self.saleItems[row * 2 + col])
                         .padding(5)
+                    }
+                    
                 }
             }
     }
     .padding(20)
-        
-        
+
+
 //        NavigationView {
 //        List {
 //                ForEach(saleItems) { singleSaleItem in
@@ -117,4 +122,7 @@ struct SaleItemTableView : View {
 //            )
 //        }
     }
+
+    }
+
 }

--- a/frontend/RaffleBay/RaffleBay/View/SignupView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/SignupView.swift
@@ -163,3 +163,8 @@ struct SignupView : View {
     }
 }
 
+struct SignupView_Previews: PreviewProvider {
+    static var previews: some View {
+        SignupView()
+    }
+}

--- a/frontend/RaffleBay/RaffleBay/View/UploadSaleItemView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/UploadSaleItemView.swift
@@ -65,12 +65,12 @@ struct CameraView: View {
 struct UploadSaleItemView : View {
    
     //Create some user and use a password confirmation var to confirm
-    @ObservedObject var newSaleItem = User()
-    @State private var pwdConfirm = String()
+    @ObservedObject var newSaleItem = SaleItem(item_name: "", pic_url: "")
+    @ObservedObject var oldSaleItem = User()
+    @State var temp_total_ticket: String = ""
     @State var value: CGFloat = 0
     
     var body: some View {
-        NavigationView {
         HStack(){
             
             //Left Side Spacer
@@ -79,11 +79,10 @@ struct UploadSaleItemView : View {
             //Center Column
             VStack(){
                 Spacer().frame(height: 80)
-                Text(newSaleItem.firstName)
                 
                 CameraView()
                 VStack(){
-                    TextField("Item Name", text: $newSaleItem.firstName)
+                    TextField("Item Name", text: $newSaleItem.item_name)
                         .textFieldStyle(SignUpTextFieldStyle())
                         .onTapGesture {
                             self.value = signupFrameHeight * 0
@@ -91,42 +90,38 @@ struct UploadSaleItemView : View {
                   
                   
                     
-                    TextField("Item Description", text: $newSaleItem.lastName)
+                    TextField("Item Description", text: $newSaleItem.item_description)
                         .textFieldStyle(SignUpTextFieldStyle())
                         .onTapGesture {
                             self.value = signupFrameHeight * 1
                         }
 
-                    TextField("Item Price", text: $newSaleItem.email)
+                    TextField("Item Price", text: $newSaleItem.sale_price)
                         .textFieldStyle(SignUpTextFieldStyle())
                         .onTapGesture {
                             self.value = signupFrameHeight * 2
                         }
 
-                    TextField("Number of Tickets", text: $newSaleItem.streetAddress)
+                    TextField("Number of Tickets", text: $newSaleItem.total_tickets)
+                        .keyboardType(.decimalPad)
                         .textFieldStyle(SignUpTextFieldStyle())
                         .onTapGesture {
                             self.value = signupFrameHeight * 5
                         }
-                    if (false) {
+                    if (newSaleItem.total_tickets != "") {
+//                        $newSaleItem.ticket_price = "1"
                         Text("Ticket Price: $5")
                     }
                     
                 }
                 
                 Spacer()
-
-                if(newSaleItem.password != pwdConfirm) {
-                    Text("Your passwords do not match.")
-                        .foregroundColor(.red)
-                    
-                }
                 //ZStack here to allow for custom shadow manipulation.
                 ZStack(){
                     ShadowBoxView()
                     
                     //Signup Button
-                    NavigationLink(destination: CreateSaleItem()){
+                    NavigationLink(destination: CreateSaleItem(newSaleItem: newSaleItem)){
                         Text("Submit")
                           .blueButtonText()
                           .frame(minWidth:0, maxWidth: frameMaxWidth)
@@ -146,7 +141,7 @@ struct UploadSaleItemView : View {
             //Right Side Spacer
             Spacer()
         }
-        }
+        
     }
 }
 

--- a/frontend/RaffleBay/RaffleBay/View/UploadSaleItemView.swift
+++ b/frontend/RaffleBay/RaffleBay/View/UploadSaleItemView.swift
@@ -1,0 +1,157 @@
+//
+//  SignupView.swift
+//  RaffleBay
+//
+//  Created by Meera Rachamallu on 2/6/20.
+//  Copyright © 2020 Meera Rachamallu. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import SwiftyJSON
+
+struct CaptureImageView {
+  
+  /// MARK: - Properties
+  @Binding var isShown: Bool
+  @Binding var image: Image?
+  
+  func makeCoordinator() -> CameraController {
+    return CameraController(isShown: $isShown, image: $image)
+  }
+}
+
+extension CaptureImageView: UIViewControllerRepresentable {
+  func makeUIViewController(context: UIViewControllerRepresentableContext<CaptureImageView>) -> UIImagePickerController {
+    let picker = UIImagePickerController()
+    picker.delegate = context.coordinator
+    /// Default is images gallery. Un-comment the next line of code if you would like to test camera
+//    picker.sourceType = .camera
+    return picker
+  }
+  
+  func updateUIViewController(_ uiViewController: UIImagePickerController,
+                              context: UIViewControllerRepresentableContext<CaptureImageView>) {
+    
+  }
+}
+
+struct CameraView: View {
+  
+  @State var image: Image? = nil
+  @State var showCaptureImageView: Bool = false
+  
+  var body: some View {
+    ZStack {
+      VStack {
+        Button(action: {
+          self.showCaptureImageView.toggle()
+        }) {
+          Text("Choose photo")
+        }
+        image?.resizable()
+          .frame(width: 250, height: 200)
+          .clipShape(Rectangle())
+          .overlay(Rectangle().stroke(Color.white, lineWidth: 4))
+          .shadow(radius: 10)
+      }
+      if (showCaptureImageView) {
+        CaptureImageView(isShown: $showCaptureImageView, image: $image)
+      }
+    }
+  }
+}
+
+struct UploadSaleItemView : View {
+   
+    //Create some user and use a password confirmation var to confirm
+    @ObservedObject var newSaleItem = User()
+    @State private var pwdConfirm = String()
+    @State var value: CGFloat = 0
+    
+    var body: some View {
+        NavigationView {
+        HStack(){
+            
+            //Left Side Spacer
+            Spacer()
+            
+            //Center Column
+            VStack(){
+                Spacer().frame(height: 80)
+                Text(newSaleItem.firstName)
+                
+                CameraView()
+                VStack(){
+                    TextField("Item Name", text: $newSaleItem.firstName)
+                        .textFieldStyle(SignUpTextFieldStyle())
+                        .onTapGesture {
+                            self.value = signupFrameHeight * 0
+                        }
+                  
+                  
+                    
+                    TextField("Item Description", text: $newSaleItem.lastName)
+                        .textFieldStyle(SignUpTextFieldStyle())
+                        .onTapGesture {
+                            self.value = signupFrameHeight * 1
+                        }
+
+                    TextField("Item Price", text: $newSaleItem.email)
+                        .textFieldStyle(SignUpTextFieldStyle())
+                        .onTapGesture {
+                            self.value = signupFrameHeight * 2
+                        }
+
+                    TextField("Number of Tickets", text: $newSaleItem.streetAddress)
+                        .textFieldStyle(SignUpTextFieldStyle())
+                        .onTapGesture {
+                            self.value = signupFrameHeight * 5
+                        }
+                    if (false) {
+                        Text("Ticket Price: $5")
+                    }
+                    
+                }
+                
+                Spacer()
+
+                if(newSaleItem.password != pwdConfirm) {
+                    Text("Your passwords do not match.")
+                        .foregroundColor(.red)
+                    
+                }
+                //ZStack here to allow for custom shadow manipulation.
+                ZStack(){
+                    ShadowBoxView()
+                    
+                    //Signup Button
+                    NavigationLink(destination: CreateSaleItem()){
+                        Text("Submit")
+                          .blueButtonText()
+                          .frame(minWidth:0, maxWidth: frameMaxWidth)
+                    }
+                    .buttonStyle(BigBlueButtonStyle())
+                }
+             
+                }
+                .offset(y: -self.value)
+                .animation(.spring())
+                .onAppear(){
+                    NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main){ (noti) in
+                        self.value = 0
+                    }
+                }
+            
+            //Right Side Spacer
+            Spacer()
+        }
+        }
+    }
+}
+
+struct UploadSaleItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        UploadSaleItemView()
+    }
+}


### PR DESCRIPTION
Added navigation to static screens. 
Added screen that allows users to upload a photo and add a new item.

Removed Navigation title buttons profile and hamburger menu bc we don't need them. A tab bar app makes more sense bc ppl equally visit the item feed page and their profile page.
We can have a logout button in place of the hamburger menu.

*Known error: When navigation from new item back to profile page, I add a navigationlink, but this pushes the profile page onto the view stack. instead, we need to figure out a way to pop off all the views on the stack to get back to the root view, which is the profile page.