### PR TITLE
Created Makefile test command for new database

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,7 +7,7 @@ build:
 
 run:
 	-pkill docker-compose
-	docker-compose up
+	DATABASE=postgres docker-compose up
 
 run_background:
 	-pkill docker-compose
@@ -15,6 +15,11 @@ run_background:
 
 stop:
 	docker-compose down
+
+test:
+	docker build -t rafflebay/test .
+	-pkill docker-compose
+	DATABASE=postgres_test docker-compose up
 
 format:
 	npx prettier --write --arrow-parens always --single-quote --trailing-comma all --no-bracket-spacing "src/**/*.js"

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -10,15 +10,23 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASS:-admin}
       POSTGRES_DB: ${POSTGRES_DB:-rafflebay}
     restart: unless-stopped
+  postgres_test:
+    image: postgres:10-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASS:-admin}
+      POSTGRES_DB: rafflebay_test
+    restart: unless-stopped
+    command: -p 5433
   backend:
     image: rafflebay/backend:latest
     ports:
       - 31337:31337
     environment:
-      POSTGRES_HOSTNAME: postgres
+      POSTGRES_HOSTNAME: ${DATABASE}
     restart: unless-stopped
     depends_on: 
-      - postgres
+      - ${DATABASE}
 
 volumes:
   rafflebay-pgdata:

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -4,13 +4,21 @@ let postgreshostname = process.env.POSTGRES_HOSTNAME;
 if (!postgreshostname) {
   postgreshostname = 'localhost';
 }
+
+let db_port = 5432
+let db_name = 'rafflebay'
+
+if (postgreshostname == 'postgres_test') {
+  db_port = 5433
+  db_name = 'rafflebay_test'
+}
 const config = {
   database: {
     user: 'postgres',
     password: 'admin',
-    port: 5432,
+    port: db_port,
     host: postgreshostname,
-    database: 'rafflebay',
+    database: db_name,
   },
   port: 31337,
   auth: {


### PR DESCRIPTION
Created new Docker setup to use a different test database when `make test` is used to start the server. This leaves the real database untouched by the tests and allows us to perform end to end tests on a real database.

TODO: The data is persisting on the test database between sessions but it is easy to delete it